### PR TITLE
Fix for Promise.done_callback (#2544)

### DIFF
--- a/telegram/ext/utils/promise.py
+++ b/telegram/ext/utils/promise.py
@@ -100,7 +100,7 @@ class Promise:
 
         finally:
             self.done.set()
-            if self._done_callback:
+            if self._exception is None and self._done_callback:
                 try:
                     self._done_callback(self.result())
                 except Exception as exc:
@@ -135,6 +135,10 @@ class Promise:
     def add_done_callback(self, callback: Callable) -> None:
         """
         Callback to be run when :class:`telegram.ext.utils.promise.Promise` becomes done.
+
+        Note:
+            Callback won't be called if :attr:`pooled_function`
+            raises an exception.
 
         Args:
             callback (:obj:`callable`): The callable that will be called when promise is done.

--- a/tests/test_promise.py
+++ b/tests/test_promise.py
@@ -136,3 +136,17 @@ class TestPromise:
         )
         assert caplog.records[1].message.startswith("Full traceback:")
         assert promise.result() == "done!"
+
+    def test_done_cb_not_run_on_excp(self):
+        def callback():
+            raise TelegramError('Error')
+
+        def done_callback(_):
+            self.test_flag = True
+
+        promise = Promise(callback, [], {})
+        promise.add_done_callback(done_callback)
+        promise.run()
+        assert isinstance(promise.exception, TelegramError)
+        assert promise.done
+        assert self.test_flag is False


### PR DESCRIPTION
* Don't call done_cb on exceptions

Signed-off-by: starry69 <starry369126@outlook.com>

* improve docs

Co-authored-by: Bibo-Joshi <hinrich.mahler@freenet.de>

* revert black

Co-authored-by: Bibo-Joshi <hinrich.mahler@freenet.de>

<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)


### If the PR contains API changes (otherwise, you can delete this passage)

* New classes:
    - [ ] Added `self._id_attrs` and corresponding documentation
    - [ ] `__init__` accepts `**_kwargs`
    
* Added new shortcuts:
    - [ ] In `Chat` & `User` for all methods that accept `chat/user_id`
    - [ ] In `Message` for all methods that accept `chat_id` and `message_id`
    - [ ] For new `Message` shortcuts: Added `quote` argument if methods accepts `reply_to_message_id`
    - [ ] In `CallbackQuery` for all methods that accept either `chat_id` and `message_id` or `inline_message_id`
    
* If relevant:

    - [ ] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [ ] Added new handlers for new update types
    - [ ] Added new filters for new message (sub)types
    - [ ] Added or updated documentation for the changed class(es) and/or method(s)
    - [ ] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`
