### PR TITLE
Fix Empty Captions not Being Passed by Bot.copy_message (#2651)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -39,6 +39,7 @@ The following wonderful people contributed directly or indirectly to this projec
 - `daimajia <https://github.com/daimajia>`_
 - `Daniel Reed <https://github.com/nmlorg>`_
 - `D David Livingston <https://github.com/daviddl9>`_
+- `DonalDuck004 <https://github.com/DonalDuck004>`_
 - `Eana Hufwe <https://github.com/blueset>`_
 - `Ehsan Online <https://github.com/ehsanonline>`_
 - `Eli Gao <https://github.com/eligao>`_

--- a/telegram/bot.py
+++ b/telegram/bot.py
@@ -5296,7 +5296,7 @@ class Bot(TelegramObject):
             'disable_notification': disable_notification,
             'allow_sending_without_reply': allow_sending_without_reply,
         }
-        if caption:
+        if caption is not None:
             data['caption'] = caption
         if caption_entities:
             data['caption_entities'] = caption_entities

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2024,7 +2024,8 @@ class TestBot:
 
     @flaky(3, 1)
     @pytest.mark.parametrize('json_keyboard', [True, False])
-    def test_copy_message(self, monkeypatch, bot, chat_id, media_message, json_keyboard):
+    @pytest.mark.parametrize('caption', ["<b>Test</b>", '', None])
+    def test_copy_message(self, monkeypatch, bot, chat_id, media_message, json_keyboard, caption):
         keyboard = InlineKeyboardMarkup(
             [[InlineKeyboardButton(text="test", callback_data="test2")]]
         )
@@ -2033,7 +2034,7 @@ class TestBot:
             assert data["chat_id"] == chat_id
             assert data["from_chat_id"] == chat_id
             assert data["message_id"] == media_message.message_id
-            assert data["caption"] == "<b>Test</b>"
+            assert data.get("caption") == caption
             assert data["parse_mode"] == ParseMode.HTML
             assert data["reply_to_message_id"] == media_message.message_id
             assert data["reply_markup"] == keyboard.to_json()
@@ -2046,7 +2047,7 @@ class TestBot:
             chat_id,
             from_chat_id=chat_id,
             message_id=media_message.message_id,
-            caption="<b>Test</b>",
+            caption=caption,
             caption_entities=[MessageEntity(MessageEntity.BOLD, 0, 4)],
             parse_mode=ParseMode.HTML,
             reply_to_message_id=media_message.message_id,


### PR DESCRIPTION
<!--
Hey! You're PRing? Cool! Please have a look at the below checklist. It's here to help both you and the maintainers to remember some aspects. Make sure to check out our contribution guide (https://github.com/python-telegram-bot/python-telegram-bot/blob/master/.github/CONTRIBUTING.rst).
-->

### Checklist for PRs

- [ ] Added `.. versionadded:: version`, `.. versionchanged:: version` or `.. deprecated:: version` to the docstrings for user facing changes (for methods/class descriptions, arguments and attributes)
- [ ] Created new or adapted existing unit tests
- [ ] Added myself alphabetically to `AUTHORS.rst` (optional)


### If the PR contains API changes (otherwise, you can delete this passage)

* New classes:
    - [ ] Added `self._id_attrs` and corresponding documentation
    - [ ] `__init__` accepts `**_kwargs`
    
* Added new shortcuts:
    - [ ] In `Chat` & `User` for all methods that accept `chat/user_id`
    - [ ] In `Message` for all methods that accept `chat_id` and `message_id`
    - [ ] For new `Message` shortcuts: Added `quote` argument if methods accepts `reply_to_message_id`
    - [ ] In `CallbackQuery` for all methods that accept either `chat_id` and `message_id` or `inline_message_id`
    
* If relevant:

    - [ ] Added new constants at `telegram.constants` and shortcuts to them as class variables
    - [ ] Added new handlers for new update types
    - [ ] Added new filters for new message (sub)types
    - [ ] Added or updated documentation for the changed class(es) and/or method(s)
    - [ ] Updated the Bot API version number in all places: `README.rst` and `README_RAW.rst` (including the badge), as well as `telegram.constants.BOT_API_VERSION`
    - [ ] Added logic for arbitrary callback data in `tg.ext.Bot` for new methods that either accept a `reply_markup` in some form or have a return type that is/contains `telegram.Message`
